### PR TITLE
Handle data with 1-d features

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,7 @@ def calculate_matmul_n_times(n_components, mat_a, mat_b):
     
     for i in range(n_components):
         mat_a_i = mat_a[:, i, :, :].squeeze(-2)
-        mat_b_i = mat_b[0, i, :, :].squeeze()
+        mat_b_i = mat_b[0, i, :, :]
         res[:, i, :, :] = mat_a_i.mm(mat_b_i).unsqueeze(1)
     
     return res


### PR DESCRIPTION
This allows the GMM model to handle data with 1-dimensional features.

Specifically, the shape of ```mat_b``` with 1-dimensional features is ```(1,k,1,1)```, and ```mat_b[0, i, :, :].squeeze()```  returns a numeric value instead of a matrix, which raises the following error:
```
Traceback (most recent call last):
  File "/media/Store4/yxc/workspace/gmm-torch/test.py", line 22, in testPredictClasses
    model.fit(x)
  File "/media/Store4/yxc/workspace/gmm-torch/gmm.py", line 149, in fit
    self.__em(x)
  File "/media/Store4/yxc/workspace/gmm-torch/gmm.py", line 365, in __em
    _, log_resp = self._e_step(x)
  File "/media/Store4/yxc/workspace/gmm-torch/gmm.py", line 317, in _e_step
    weighted_log_prob = self._estimate_log_prob(x) + torch.log(self.pi)
  File "/media/Store4/yxc/workspace/gmm-torch/gmm.py", line 275, in _estimate_log_prob
    x_mu_T_precision = calculate_matmul_n_times(self.n_components, x_mu_T, precision)
  File "/media/Store4/yxc/workspace/gmm-torch/utils.py", line 16, in calculate_matmul_n_times
    res[:, i, :, :] = mat_a_i.mm(mat_b_i).unsqueeze(1)
RuntimeError: mat2 must be a matrix
```

This can be solved by removing the ```squeeze()``` function.